### PR TITLE
Parser fixes

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -169,6 +169,9 @@ cython_debug/
 #  option (not recommended) you can uncomment the following to ignore the entire idea folder.
 .idea/
 
+#VSCode metadata
+.vscode
+
 # Ruff stuff:
 .ruff_cache/
 

--- a/OSA/osatreesitter/docgen.py
+++ b/OSA/osatreesitter/docgen.py
@@ -57,17 +57,14 @@ class DocGen(object):
             file structure and for each class or standalone function, generating its documentation.
     """
 
-    def __init__(
-            self,
-            config_loader: Union[ConfigLoader, ArticleConfigLoader]):
+    def __init__(self, config_loader: Union[ConfigLoader, ArticleConfigLoader]):
         """
         Instantiates the object of the class.
 
         This method is a constructor that initializes the object by setting the 'api_key' attribute to the value of the 'OPENAI_API_KEY' environment variable.
         """
         self.config = config_loader.config
-        self.model_handler: ModelHandler = ModelHandlerFactory.build(
-            self.config)
+        self.model_handler: ModelHandler = ModelHandlerFactory.build(self.config)
 
     @staticmethod
     def format_structure_openai(structure: dict) -> str:
@@ -203,14 +200,12 @@ class DocGen(object):
         match = re.search(r'("""+)\n?(.*?)\n?\1', gpt_response, re.DOTALL)
 
         if match:
-            triple_quotes = match.group(
-                1)  # Keep the triple quotes (""" or """)
+            triple_quotes = match.group(1)  # Keep the triple quotes (""" or """)
             extracted_docstring = match.group(
                 2
             )  # Extract only the content inside the docstring
             cleaned_content = re.sub(
-                r"^\s*def\s+\w+\(.*?\):\s*", "", extracted_docstring,
-                flags=re.MULTILINE
+                r"^\s*def\s+\w+\(.*?\):\s*", "", extracted_docstring, flags=re.MULTILINE
             )
 
             return f"{triple_quotes}\n{cleaned_content}{triple_quotes}"
@@ -218,10 +213,7 @@ class DocGen(object):
         return '"""No valid docstring found."""'  # Return a placeholder if no docstring was found
 
     def insert_docstring_in_code(
-            self,
-            source_code: str,
-            method_details: dict,
-            generated_docstring: str
+        self, source_code: str, method_details: dict, generated_docstring: str
     ) -> str:
         """
         This method inserts a generated docstring into the specified location in the source code.
@@ -239,20 +231,15 @@ class DocGen(object):
         # including an optional return type. Ensures no docstring follows.
         method_pattern = rf"((?:@\w+(?:\([^)]*\))?\s*\n)*\s*(?:async\s+)?def\s+{method_details['method_name']}\s*\(.*?\)\s*(->\s*[a-zA-Z0-9_\[\], ]+)?\s*:\n)(\s*)(?!\s*\"\"\")"
 
-        docstring_with_format = self.extract_pure_docstring(
-            generated_docstring)
+        docstring_with_format = self.extract_pure_docstring(generated_docstring)
         updated_code = re.sub(
-            method_pattern, rf"\1\3{docstring_with_format}\n\3", source_code,
-            count=1
+            method_pattern, rf"\1\3{docstring_with_format}\n\3", source_code, count=1
         )
 
         return updated_code
 
     def insert_cls_docstring_in_code(
-            self,
-            source_code: str,
-            class_name: str,
-            generated_docstring: str
+        self, source_code: str, class_name: str, generated_docstring: str
     ) -> str:
         """
         Inserts a generated class docstring into the class definition.
@@ -274,12 +261,10 @@ class DocGen(object):
         )
 
         # Ensure we keep only the extracted docstring
-        docstring_with_format = self.extract_pure_docstring(
-            generated_docstring)
+        docstring_with_format = self.extract_pure_docstring(generated_docstring)
 
         updated_code = re.sub(
-            class_pattern, rf"\1\3{docstring_with_format}\n\3", source_code,
-            count=1
+            class_pattern, rf"\1\3{docstring_with_format}\n\3", source_code, count=1
         )
 
         return updated_code
@@ -306,8 +291,7 @@ class DocGen(object):
             for item in structure:
                 if item["type"] == "class":
                     for method in item["methods"]:
-                        if method[
-                            "docstring"] == None:  # If docstring is missing
+                        if method["docstring"] == None:  # If docstring is missing
                             logging.info(
                                 f"Generating docstring for method: {method['method_name']} in class {item['name']} at {filename}"
                             )
@@ -315,8 +299,7 @@ class DocGen(object):
                                 method
                             )
                             if item["docstring"] == None:
-                                method[
-                                    "docstring"] = self.extract_pure_docstring(
+                                method["docstring"] = self.extract_pure_docstring(
                                     generated_docstring
                                 )
                             source_code = self.insert_docstring_in_code(

--- a/OSA/osatreesitter/docgen.py
+++ b/OSA/osatreesitter/docgen.py
@@ -155,14 +155,14 @@ class DocGen(object):
         """
         # Construct a structured prompt
         prompt = f"""
-        Generate a single Python docstring for the following class {class_details[0]['class_name']}. The docstring should follow Google-style format and include:
+        Generate a single Python docstring for the following class {class_details[0]}. The docstring should follow Google-style format and include:
         - A short summary of what the class does.
         - A list of its methods.
         - A brief description of its methods.
 
         Class Methods:
         """
-        for method in class_details:
+        for method in class_details[1:]:
             prompt += f"- {method['method_name']}: {method['docstring']}\n"
 
         return self.model_handler.send_request(prompt)
@@ -237,7 +237,7 @@ class DocGen(object):
         """
         # Matches a method definition with the given name,
         # including an optional return type. Ensures no docstring follows.
-        method_pattern = rf"(def\s+{method_details['method_name']}\s*\([^)]*\)\s*(->\s*[a-zA-Z0-9_\[\], ]+)?\s*:\n)(\s*)(?!\s*\"\"\")"
+        method_pattern = rf"((?:@\w+(?:\([^)]*\))?\s*\n)*\s*(?:async\s+)?def\s+{method_details['method_name']}\s*\(.*?\)\s*(->\s*[a-zA-Z0-9_\[\], ]+)?\s*:\n)(\s*)(?!\s*\"\"\")"
 
         docstring_with_format = self.extract_pure_docstring(
             generated_docstring)
@@ -339,10 +339,10 @@ class DocGen(object):
                 if item["type"] == "class" and item["docstring"] == None:
                     class_name = item["name"]
                     cls_structure = []
+                    cls_structure.append(class_name)
                     for method in item["methods"]:
                         cls_structure.append(
                             {
-                                "class_name": class_name,
                                 "method_name": method["method_name"],
                                 "docstring": method["docstring"],
                             }

--- a/OSA/osatreesitter/docgen.py
+++ b/OSA/osatreesitter/docgen.py
@@ -154,13 +154,17 @@ class DocGen(object):
         prompt = f"""
         Generate a single Python docstring for the following class {class_details[0]}. The docstring should follow Google-style format and include:
         - A short summary of what the class does.
-        - A list of its methods.
-        - A brief description of its methods.
+        - A list of its methods and attributes without details.
+        - A brief summary of what its methods and attributes do.
 
         Class Methods:
         """
-        for method in class_details[1:]:
+        for method in class_details[2:]:
             prompt += f"- {method['method_name']}: {method['docstring']}\n"
+
+        prompt += f"\nClass Attributes:\n"
+        for attr in class_details[1]:
+            prompt += f"- {attr}\n"
 
         return self.model_handler.send_request(prompt)
 
@@ -171,11 +175,12 @@ class DocGen(object):
         prompt = f"""
         Generate a Python docstring for the following method. The docstring should follow Google-style format and include:
         - A short summary of what the method does.
-        - A description of its parameters with types.
+        - A description of its parameters without types.
         - The return type and description.
 
         Method Details:
         - Method Name: {method_details["method_name"]}
+        - Method decorators: {method_details["decorators"]}
         - Arguments: {method_details["arguments"]}
         - Return Type: {method_details["return_type"]}
         - Docstring: {method_details["docstring"]}
@@ -323,6 +328,7 @@ class DocGen(object):
                     class_name = item["name"]
                     cls_structure = []
                     cls_structure.append(class_name)
+                    cls_structure.append(item["attributes"])
                     for method in item["methods"]:
                         cls_structure.append(
                             {

--- a/OSA/osatreesitter/docgen.py
+++ b/OSA/osatreesitter/docgen.py
@@ -154,17 +154,19 @@ class DocGen(object):
         prompt = f"""
         Generate a single Python docstring for the following class {class_details[0]}. The docstring should follow Google-style format and include:
         - A short summary of what the class does.
-        - A list of its methods and attributes without details.
-        - A brief summary of what its methods and attributes do.
-
-        Class Methods:
+        - A list of its methods without details if class has them otherwise do not mention a list of methods.
+        - A list of its attributes without types if class has them otherwise do not mention a list of attributes.
+        - A brief summary of what its methods and attributes do if one has them for.
         """
-        for method in class_details[2:]:
-            prompt += f"- {method['method_name']}: {method['docstring']}\n"
+        if len(class_details[1]) > 0:
+            prompt += f"\nClass Attributes:\n"
+            for attr in class_details[1]:
+                prompt += f"- {attr}\n"
 
-        prompt += f"\nClass Attributes:\n"
-        for attr in class_details[1]:
-            prompt += f"- {attr}\n"
+        if len(class_details[2:]) > 0:
+            prompt += f"\nClass Methods:\n"
+            for method in class_details[2:]:
+                prompt += f"- {method['method_name']}: {method['docstring']}\n"
 
         return self.model_handler.send_request(prompt)
 

--- a/OSA/osatreesitter/docgen.py
+++ b/OSA/osatreesitter/docgen.py
@@ -234,7 +234,7 @@ class DocGen(object):
         """
         # Matches a method definition with the given name,
         # including an optional return type. Ensures no docstring follows.
-        method_pattern = rf"((?:@\w+(?:\([^)]*\))?\s*\n)*\s*(?:async\s+)?def\s+{method_details['method_name']}\s*\(.*?\)\s*(->\s*[a-zA-Z0-9_\[\], ]+)?\s*:\n)(\s*)(?!\s*\"\"\")"
+        method_pattern = rf"((?:@\w+(?:\([^)]*\))?\s*\n)*\s*(?:async\s+)?def\s+{method_details['method_name']}\s*\([\s\S]*?\)\s*(->\s*[a-zA-Z0-9_\[\], ]+)?\s*:\n)(\s*)(?!\s*\"\"\")"
 
         docstring_with_format = self.extract_pure_docstring(generated_docstring)
         updated_code = re.sub(

--- a/OSA/osatreesitter/osa_treesitter.py
+++ b/OSA/osatreesitter/osa_treesitter.py
@@ -104,7 +104,7 @@ class OSA_TreeSitter(object):
         parser: Parser = self._parser_build(filename)
         source_code: str = self.open_file(filename)
         return (parser.parse(source_code.encode("utf-8")), source_code)
-    
+
     def _class_parser(self, structure: list, source_code: str, node: tree_sitter.Node):
         print(node.children)
         class_name = node.child_by_field_name("name").text.decode("utf-8")
@@ -130,9 +130,7 @@ class OSA_TreeSitter(object):
                     class_methods.append(method)
 
             if child.type == "function_definition":
-                method_details = self._extract_function_details(
-                    child, source_code
-                )
+                method_details = self._extract_function_details(child, source_code)
                 class_methods.append(method_details)
 
         structure.append(
@@ -147,11 +145,11 @@ class OSA_TreeSitter(object):
 
         return structure
 
-    def _function_parser(self, structure: list, source_code: str, node: tree_sitter.Node):
+    def _function_parser(
+        self, structure: list, source_code: str, node: tree_sitter.Node
+    ):
         method_details = self._extract_function_details(node, source_code)
-        start_line = (
-            node.start_point[0] + 1
-        )  # convert 0-based to 1-based indexing
+        start_line = node.start_point[0] + 1  # convert 0-based to 1-based indexing
         structure.append(
             {
                 "type": "function",
@@ -184,7 +182,9 @@ class OSA_TreeSitter(object):
                         structure = self._class_parser(structure, source_code, dec_node)
 
                     elif dec_node.type == "function_definition":
-                        structure = self._function_parser(structure, source_code, dec_node)
+                        structure = self._function_parser(
+                            structure, source_code, dec_node
+                        )
 
             elif node.type == "function_definition":
                 structure = self._function_parser(structure, source_code, node)

--- a/main.py
+++ b/main.py
@@ -41,7 +41,7 @@ def main():
         "--repository",
         type=str,
         help="URL of the GitHub repository",
-        required=True
+        required=True,
     )
     parser.add_argument(
         "--api",
@@ -78,9 +78,7 @@ def main():
     parser.add_argument(
         "--translate-dirs",
         action="store_true",
-        help=(
-            "Enable automatic translation of the directory name into English."
-        ),
+        help=("Enable automatic translation of the directory name into English."),
     )
 
     args = parser.parse_args()
@@ -133,9 +131,7 @@ def generate_docstrings(config_loader) -> None:
         dg.process_python_file(res)
 
     except Exception as e:
-        logger.error("Error while docstring generation: %s", repr(e),
-                     exc_info=True)
-        raise ValueError("Failed to generate docstrings.")
+        logger.error("Error while docstring generation: %s", repr(e), exc_info=True)
 
 
 def readme_agent(config_loader, article: Optional[str]) -> None:
@@ -149,21 +145,18 @@ def readme_agent(config_loader, article: Optional[str]) -> None:
         Exception: If an error occurs during README.md generation.
     """
     repo_url = config_loader.config.git.repository
-    logger.info("Started generating README.md. Processing the repository: %s"
-                , repo_url)
+    logger.info("Started generating README.md. Processing the repository: %s", repo_url)
 
     try:
         # Define output directory and ensure it exists
-        output_dir = os.path.join(os.getcwd(), parse_folder_name(repo_url)
-                                  )
+        output_dir = os.path.join(os.getcwd(), parse_folder_name(repo_url))
         os.makedirs(output_dir, exist_ok=True)
         file_to_save = os.path.join(output_dir, "README.md")
 
         # Generate README.md
         readme_generator(config_loader, file_to_save, article)
 
-        logger.info("README.md successfully generated in folder: %s",
-                    output_dir)
+        logger.info("README.md successfully generated in folder: %s", output_dir)
 
     except Exception as e:
         logger.error("Error while generating: %s", repr(e), exc_info=True)
@@ -171,27 +164,21 @@ def readme_agent(config_loader, article: Optional[str]) -> None:
 
 
 def load_configuration(
-        repo_url: str,
-        api: str,
-        model_name: str,
-        article: Optional[str]
+    repo_url: str, api: str, model_name: str, article: Optional[str]
 ):
     if article is None:
 
         config_loader = ConfigLoader(
-            config_dir=os.path.join(osa_project_root(), "OSA", "config",
-                                    "standart"))
+            config_dir=os.path.join(osa_project_root(), "OSA", "config", "standart")
+        )
     else:
         config_loader = ArticleConfigLoader(
-            config_dir=os.path.join(osa_project_root(), "OSA", "config",
-                                    "with_article"))
+            config_dir=os.path.join(osa_project_root(), "OSA", "config", "with_article")
+        )
 
     config_loader.config.git = GitSettings(repository=repo_url)
     config_loader.config.llm = config_loader.config.llm.model_copy(
-        update={
-            "api": api,
-            "model": model_name
-        }
+        update={"api": api, "model": model_name}
     )
     logger.info("Config successfully updated and loaded")
     return config_loader

--- a/tests/unit/test_osatreesitter/test_osatreesitter.py
+++ b/tests/unit/test_osatreesitter/test_osatreesitter.py
@@ -1,0 +1,160 @@
+import pytest
+import os
+from unittest.mock import patch, mock_open, MagicMock
+from OSA.osatreesitter.osa_treesitter import OSA_TreeSitter
+
+
+@pytest.fixture
+def osa_tree_sitter():
+    """Создание фикстуры OSA_TreeSitter для повторного использования."""
+    return OSA_TreeSitter("test_directory")
+
+
+@patch("os.path.isdir", return_value=True)
+@patch("os.walk", return_value=[("test_directory", [], ["script.py", "test.txt"])])
+def test_files_list_directory(mock_walk, mock_isdir, osa_tree_sitter):
+    """Test that files_list correctly identifies Python files in a directory."""
+    files, status = osa_tree_sitter.files_list("test_directory")
+
+    expected_files = [os.path.join("test_directory", "script.py")]
+
+    assert files == expected_files
+    assert status == 0
+
+
+@patch("os.path.isfile", return_value=True)
+@patch("os.path.abspath", return_value="/absolute/path/to/script.py")
+def test_files_list_file(mock_abspath, mock_isfile, osa_tree_sitter):
+    """Test that files_list correctly handles a single file path."""
+    files, status = osa_tree_sitter.files_list("script.py")
+    assert files == ["/absolute/path/to/script.py"]
+    assert status == 1
+
+
+def test_if_file_handler(osa_tree_sitter):
+    """Test _if_file_handler returns the directory path."""
+    path = "/path/to/script.py"
+    result = osa_tree_sitter._if_file_handler(path)
+    assert result == "/path/to"
+
+
+@patch("builtins.open", new_callable=mock_open, read_data="print('Hello')")
+def test_open_file(mock_file, osa_tree_sitter):
+    """Test open_file correctly reads a file's content."""
+    content = osa_tree_sitter.open_file("script.py")
+    assert content == "print('Hello')"
+
+
+@patch("tree_sitter.Parser")
+@patch("OSA.osatreesitter.osa_treesitter.OSA_TreeSitter._parser_build")
+@patch(
+    "OSA.osatreesitter.osa_treesitter.OSA_TreeSitter.open_file",
+    return_value="def test(): pass",
+)
+def test_parse_source_code(
+    mock_open_file, mock_parser_build, mock_parser, osa_tree_sitter
+):
+    """Test _parse_source_code returns a parsed tree."""
+    mock_parser_build.return_value = mock_parser
+    mock_parser.parse.return_value = "mock_tree"
+
+    tree, source_code = osa_tree_sitter._parse_source_code("script.py")
+
+    assert tree == "mock_tree"
+    assert source_code == "def test(): pass"
+
+
+@patch("OSA.osatreesitter.osa_treesitter.OSA_TreeSitter._class_parser")
+@patch("OSA.osatreesitter.osa_treesitter.OSA_TreeSitter._function_parser")
+@patch("OSA.osatreesitter.osa_treesitter.OSA_TreeSitter._parse_source_code")
+@patch(
+    "OSA.osatreesitter.osa_treesitter.OSA_TreeSitter._get_decorators",
+    return_value=["mock_decorator"],
+)
+def test_extract_structure(
+    mock_get_decorators,
+    mock_parse_source_code,
+    mock_function_parser,
+    mock_class_parser,
+    osa_tree_sitter,
+):
+    """Test extract_structure processes functions, classes, and decorators in a Python file."""
+
+    with patch.object(
+        OSA_TreeSitter, "_function_parser"
+    ) as mock_function_parser, patch.object(
+        OSA_TreeSitter, "_class_parser"
+    ) as mock_class_parser:
+
+        mock_tree = MagicMock()
+        mock_tree.root_node = MagicMock()
+
+        mock_decorated_node = MagicMock()
+        mock_decorated_node.type = "decorated_definition"
+        mock_function_node = MagicMock()
+        mock_function_node.type = "function_definition"
+        mock_decorated_node.children = [MagicMock(type="decorator"), mock_function_node]
+
+        mock_class_node = MagicMock()
+        mock_class_node.type = "class_definition"
+
+        mock_tree.root_node.children = [
+            mock_decorated_node,
+            mock_class_node,
+            mock_function_node,
+        ]
+        mock_parse_source_code.return_value = (mock_tree, "def test(): pass")
+
+        def function_parser_side_effect(structure, source_code, node, dec_list=[]):
+            new_structure = structure.copy()
+            new_structure.append(f"mock_function_structure_{len(new_structure)}")
+            return new_structure
+
+        def class_parser_side_effect(structure, source_code, node, dec_list=[]):
+            new_structure = structure.copy()
+            new_structure.append(f"mock_class_structure_{len(new_structure)}")
+            return new_structure
+
+        mock_function_parser.side_effect = function_parser_side_effect
+        mock_class_parser.side_effect = class_parser_side_effect
+
+        result = osa_tree_sitter.extract_structure("script.py")
+
+        print(mock_get_decorators.call_args_list)
+        print(mock_function_parser.call_args_list)
+
+        mock_get_decorators.assert_called_with([], mock_decorated_node.children[0])
+        mock_function_parser.assert_any_call(
+            [], "def test(): pass", mock_decorated_node.children[1], ["mock_decorator"]
+        )
+        mock_class_parser.assert_any_call(
+            ["mock_function_structure_0"], "def test(): pass", mock_class_node
+        )
+        mock_function_parser.assert_any_call(
+            ["mock_function_structure_0", "mock_class_structure_1"],
+            "def test(): pass",
+            mock_function_node,
+        )
+
+        assert result == [
+            "mock_function_structure_0",
+            "mock_class_structure_1",
+            "mock_function_structure_2",
+        ]
+
+        mock_parse_source_code.assert_called_with("script.py")
+
+
+@patch(
+    "OSA.osatreesitter.osa_treesitter.OSA_TreeSitter.files_list",
+    return_value=(["script.py"], 0),
+)
+@patch(
+    "OSA.osatreesitter.osa_treesitter.OSA_TreeSitter.extract_structure",
+    return_value=[{"type": "function", "name": "test"}],
+)
+def test_analyze_directory(mock_extract_structure, mock_files_list, osa_tree_sitter):
+    """Test analyze_directory correctly processes all Python files."""
+    result = osa_tree_sitter.analyze_directory("test_directory")
+    assert "script.py" in result
+    assert result["script.py"] == [{"type": "function", "name": "test"}]


### PR DESCRIPTION
*пофиксил баг, когда докген падал на классе без методов 
*теперь для докстринга класса дополнительно передаются названия его аттрибутов 
*прошелся по дополнительным краевым случаям и исправил проблему, когда докгены не вставлялись для методов и функций, обернутых в декораторы
*исправил промпт, чтобы в докстринге не дублировались в скобках типы аргументов
*убрал raise из exception'а, чтобы не прерывать workflow осы