### PR TITLE
Report JSON processing workaround

### DIFF
--- a/osa_tool/analytics/report_generator.py
+++ b/osa_tool/analytics/report_generator.py
@@ -1,5 +1,6 @@
 import json
 import os
+from json import JSONDecodeError
 
 import tomli as tomllib
 from pydantic import ValidationError
@@ -43,7 +44,11 @@ class TextGenerator:
         """
         response = self.model_handler.send_request(self._build_prompt())
         try:
-            parsed_json = json.loads(response)
+            try:
+                parsed_json = json.loads(response)
+            except JSONDecodeError:
+                # workaround if response starts with ```json and ends with ```
+                parsed_json = json.loads(response.replace('```json', '').replace('```', ''))
             parsed_report = RepositoryReport.model_validate(parsed_json)
 
             return parsed_report

--- a/osa_tool/analytics/report_generator.py
+++ b/osa_tool/analytics/report_generator.py
@@ -11,7 +11,7 @@ from osa_tool.analytics.sourcerank import SourceRank
 from osa_tool.models.models import ModelHandler, ModelHandlerFactory
 from osa_tool.readmeai.config.settings import ConfigLoader
 from osa_tool.readmeai.readmegen_article.config.settings import ArticleConfigLoader
-from osa_tool.utils import parse_folder_name, osa_project_root
+from osa_tool.utils import parse_folder_name, osa_project_root, logger
 
 
 class TextGenerator:
@@ -49,6 +49,7 @@ class TextGenerator:
             except JSONDecodeError:
                 # workaround if response starts with ```json and ends with ```
                 parsed_json = json.loads(response.replace('```json', '').replace('```', ''))
+                logger.info(f"JSON from model response is infested with ```. Auto-cleaning workaround applied.")
             parsed_report = RepositoryReport.model_validate(parsed_json)
 
             return parsed_report


### PR DESCRIPTION
Workaround for problem with report's JSON encountered in Python 3.10/Win11:

![image](https://github.com/user-attachments/assets/6ea12c34-75a2-45d9-9e90-fcd9e972c413)
